### PR TITLE
chore: allow build without Boost Stacktrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ OPTION (BUILD_CODE_COVERAGE "Build code coverage" OFF)
 OPTION (BUILD_DOCUMENTATION "Build documentation" OFF)
 OPTION (BUILD_WITH_DEBUG_SYMBOLS "Build with debug symbols" ON)
 OPTION (BUILD_WITH_CXX_17 "Build with C++ 17 support." OFF)
+OPTION (BUILD_WITH_BOOST_STACKTRACE "Build with Boost Stacktrace instead of stacktrace basic" ON)
+OPTION (BUILD_WITH_BOOST_STATIC "Build with Boost Static lib" ON)
 
 ## Setup
 
@@ -31,7 +33,7 @@ CMAKE_MINIMUM_REQUIRED (VERSION "2.8.12" FATAL_ERROR)
 
 ### Paths
 
-SET (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
+LIST (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
 ### Policies
 
@@ -128,7 +130,7 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             MESSAGE (FATAL_ERROR "GCC version must be at least 7.0 to build with C++17")
 
         ENDIF ()
-    
+
     ELSE ()
 
         MESSAGE (STATUS "C++20 support enabled")
@@ -140,7 +142,7 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
             MESSAGE (FATAL_ERROR "GCC version must be at least 13.0 to build with C++20")
 
         ENDIF ()
-    
+
     ENDIF ()
 
     SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Wno-deprecated")
@@ -235,26 +237,33 @@ ENDFOREACH ()
 
 ### Boost [1.82.0]
 
-SET (Boost_USE_STATIC_LIBS ON)
-SET (Boost_USE_MULTITHREADED ON)
+IF (BUILD_WITH_BOOST_STATIC)
+    SET (Boost_USE_STATIC_LIBS ON)
+ELSE ()
+    SET (Boost_USE_STATIC_LIBS OFF)
+ENDIF ()
 
-FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "url" "system" "filesystem" "regex" "log")
+IF (BUILD_WITH_BOOST_STACKTRACE)
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "url" "system" "filesystem" "regex" "log")
 
-## Stacktrace definitions
-# Detect system architecture
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    # Architecture-specific include for x86_64
-    set(BACKTRACE_INCLUDE "/usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    # Example path adjustment for aarch64, adjust the path as needed
-    set(BACKTRACE_INCLUDE "/usr/lib/gcc/aarch64-linux-gnu/9/include/backtrace.h")
-else()
-    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-endif()
+    ## Stacktrace definitions
+    # Detect system architecture
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+        # Architecture-specific include for x86_64
+        set(BACKTRACE_INCLUDE "/usr/lib/gcc/x86_64-linux-gnu/9/include/backtrace.h")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        # Example path adjustment for aarch64, adjust the path as needed
+        set(BACKTRACE_INCLUDE "/usr/lib/gcc/aarch64-linux-gnu/9/include/backtrace.h")
+    else()
+        message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
 
-# Add definitions with architecture-specific path
-ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE)
-ADD_DEFINITIONS(-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
+    # Add definitions with architecture-specific path
+    ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE)
+    ADD_DEFINITIONS(-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
+ELSE ()
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "url" "system" "filesystem" "regex" "log" "stacktrace_basic")
+ENDIF()
 
 IF (NOT Boost_FOUND)
     MESSAGE (SEND_ERROR "[Boost] not found.")
@@ -435,22 +444,22 @@ ENDIF ()
 ### Configuration
 
 CONFIGURE_FILE (
-    "${CMAKE_MODULE_PATH}/${PROJECT_NAME}Config.cmake.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/${PROJECT_NAME}Config.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     @ONLY)
 
 CONFIGURE_FILE (
-    "${CMAKE_MODULE_PATH}/${PROJECT_NAME}ConfigVersion.cmake.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/${PROJECT_NAME}ConfigVersion.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
     @ONLY)
 
-INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" DESTINATION "${INSTALL_LIB}/${PROJECT_NAME}" COMPONENT "libraries")
-INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" DESTINATION "${INSTALL_LIB}/${PROJECT_NAME}" COMPONENT "libraries")
+INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" DESTINATION "${INSTALL_LIB}/cmake/${PROJECT_NAME}" COMPONENT "libraries")
+INSTALL (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" DESTINATION "${INSTALL_LIB}/cmake/${PROJECT_NAME}" COMPONENT "libraries")
 
 ### Uninstall
 
 CONFIGURE_FILE (
-    "${CMAKE_MODULE_PATH}/UninstallTarget.cmake.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake/UninstallTarget.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/UninstallTarget.cmake"
     IMMEDIATE @ONLY)
 


### PR DESCRIPTION
This MR allows building OSTk Core without Boost Stacktrace (use basic Stacktrace instead) due to some target incompatibility with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new build options for enhanced configurability: 
		- `BUILD_WITH_BOOST_STACKTRACE` (default ON)
		- `BUILD_WITH_BOOST_STATIC` (default OFF)
- **Improvements**
	- Enhanced module path management for better flexibility.
	- Updated installation paths for improved organization of configuration files.
	- Improved logic for Boost library configuration based on new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->