### PR TITLE
fix: use absolute path of package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,7 @@ ci-test-python: ## Run Python unit tests. Assumes the dev image has already been
 	--volume="/app/build" \
 	--workdir=/app/build \
 	$(docker_development_image_repository):$(docker_image_version) \
-	/bin/bash -c "python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} --find-links packages/python open_space_toolkit_${project_name} \
+	/bin/bash -c "python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} --find-links /app/packages/python open_space_toolkit_${project_name} \
 	&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} plotly pandas \
 	&& cd ${test_python_directory}/ostk/$(project_name)/ \
 	&& python${test_python_version} -m pytest -sv ."


### PR DESCRIPTION
Paths to the packaged whls are prefixed with /app/, but the --find-links path was missing this, so previously they [weren't getting found correctly](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12712001256/job/35436795862#step:6:22). This meant that rather installing the bindings built from the previous step, pypi was instead falling back to whatever was on pypi.

This [run](https://github.com/open-space-collective/open-space-toolkit-core/actions/runs/12785079201/job/35640663563) [intentionally introduces](https://github.com/open-space-collective/open-space-toolkit-core/pull/180/commits/362d7612c2b450c58c9796a2d7ca68a4504e1ddb) an exception to cause the tests to fail, demonstrating that the pipeline is indeed using the locally-built bindings rather than what's available on pypi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Makefile configuration for package installation path
	- Modified CI test Python target to use absolute path for package lookup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->