### PR TITLE
style: reapply clang-format

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitIOPy/URL.cpp
+++ b/bindings/python/src/OpenSpaceToolkitIOPy/URL.cpp
@@ -19,15 +19,17 @@ inline void OpenSpaceToolkitIOPy_URL(pybind11::module& aModule)
     class_<URL> url_class(aModule, "URL");
 
     url_class
-        .def(init<
-             const String&,
-             const String&,
-             const String&,
-             const Integer&,
-             const String&,
-             const String&,
-             const Query&,
-             const String&>())
+        .def(
+            init<
+                const String&,
+                const String&,
+                const String&,
+                const Integer&,
+                const String&,
+                const String&,
+                const Query&,
+                const String&>()
+        )
 
         .def(self == self)
         .def(self != self)

--- a/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Client.cpp
+++ b/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Client.cpp
@@ -206,9 +206,11 @@ File Client::Fetch(const URL& aUrl, const Directory& aDirectory, const Size& aFo
 
         // Set response data handler
 
-        file = File::Path(Path::Parse(
-            String::Format("{}/{}", aDirectory.getPath().toString(), Path::Parse(aUrl.getPath()).getLastElement())
-        ));
+        file = File::Path(
+            Path::Parse(
+                String::Format("{}/{}", aDirectory.getPath().toString(), Path::Parse(aUrl.getPath()).getLastElement())
+            )
+        );
 
         FILE* filePtr = fopen(file.getPath().toString().data(), "wb");
 

--- a/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Response.cpp
+++ b/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Response.cpp
@@ -27,11 +27,12 @@ std::ostream& operator<<(std::ostream& anOutputStream, const Response& aResponse
 {
     ostk::core::utils::Print::Header(anOutputStream, "Response");
 
-    ostk::core::utils::Print::Line(anOutputStream
-    ) << "Status code:"
-      << String::Format(
-             "{} - {}", static_cast<uint>(aResponse.statusCode_), Response::StringFromStatusCode(aResponse.statusCode_)
-         );
+    ostk::core::utils::Print::Line(anOutputStream) << "Status code:"
+                                                   << String::Format(
+                                                          "{} - {}",
+                                                          static_cast<uint>(aResponse.statusCode_),
+                                                          Response::StringFromStatusCode(aResponse.statusCode_)
+                                                      );
     ostk::core::utils::Print::Line(anOutputStream) << "Body:" << aResponse.body_;
 
     ostk::core::utils::Print::Footer(anOutputStream);


### PR DESCRIPTION
Re-run `clang-format` through the codebase using `clang-format-20`; contains no changes to business logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Improved code formatting in Python bindings for the `URL` class constructor.
	- Reformatted `File` object instantiation in HTTP Client for better readability.
	- Enhanced indentation in the `Response` class's output function for clarity.

Note: These changes are purely stylistic and do not impact the functionality of the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->