### PR TITLE
build: loosen boost version req to 1.82

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ ENDFOREACH ()
 
 ## Dependencies
 
-### Boost [1.87.0]
+### Boost [1.82.0]
 
 IF (BUILD_WITH_BOOST_STATIC)
     SET (Boost_USE_STATIC_LIBS ON)
@@ -244,7 +244,7 @@ ELSE ()
 ENDIF ()
 
 IF (BUILD_WITH_BOOST_STACKTRACE)
-    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "url" "system" "filesystem" "regex" "log")
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "url" "system" "filesystem" "regex" "log")
 
     ## Stacktrace definitions
     # Detect system architecture
@@ -262,7 +262,7 @@ IF (BUILD_WITH_BOOST_STACKTRACE)
     ADD_DEFINITIONS(-DBOOST_STACKTRACE_USE_BACKTRACE)
     ADD_DEFINITIONS(-DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=<${BACKTRACE_INCLUDE}>)
 ELSE ()
-    FIND_PACKAGE ("Boost" "1.87" REQUIRED COMPONENTS "url" "system" "filesystem" "regex" "log" "stacktrace_basic")
+    FIND_PACKAGE ("Boost" "1.82" REQUIRED COMPONENTS "url" "system" "filesystem" "regex" "log" "stacktrace_basic")
 ENDIF()
 
 IF (NOT Boost_FOUND)


### PR DESCRIPTION
See https://github.com/open-space-collective/open-space-toolkit-core/pull/187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
	- Reduced required Boost library version from 1.87.0 to 1.82.0
	- Updated Boost package requirements for core library components and stacktrace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->