### PR TITLE
style: re-run format with clang 18

### DIFF
--- a/bindings/python/src/OpenSpaceToolkitIOPy/URL.cpp
+++ b/bindings/python/src/OpenSpaceToolkitIOPy/URL.cpp
@@ -19,17 +19,15 @@ inline void OpenSpaceToolkitIOPy_URL(pybind11::module& aModule)
     class_<URL> url_class(aModule, "URL");
 
     url_class
-        .def(
-            init<
-                const String&,
-                const String&,
-                const String&,
-                const Integer&,
-                const String&,
-                const String&,
-                const Query&,
-                const String&>()
-        )
+        .def(init<
+             const String&,
+             const String&,
+             const String&,
+             const Integer&,
+             const String&,
+             const String&,
+             const Query&,
+             const String&>())
 
         .def(self == self)
         .def(self != self)

--- a/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Client.cpp
+++ b/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Client.cpp
@@ -206,11 +206,9 @@ File Client::Fetch(const URL& aUrl, const Directory& aDirectory, const Size& aFo
 
         // Set response data handler
 
-        file = File::Path(
-            Path::Parse(
-                String::Format("{}/{}", aDirectory.getPath().toString(), Path::Parse(aUrl.getPath()).getLastElement())
-            )
-        );
+        file = File::Path(Path::Parse(
+            String::Format("{}/{}", aDirectory.getPath().toString(), Path::Parse(aUrl.getPath()).getLastElement())
+        ));
 
         FILE* filePtr = fopen(file.getPath().toString().data(), "wb");
 

--- a/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Response.cpp
+++ b/src/OpenSpaceToolkit/IO/IP/TCP/HTTP/Response.cpp
@@ -27,12 +27,11 @@ std::ostream& operator<<(std::ostream& anOutputStream, const Response& aResponse
 {
     ostk::core::utils::Print::Header(anOutputStream, "Response");
 
-    ostk::core::utils::Print::Line(anOutputStream) << "Status code:"
-                                                   << String::Format(
-                                                          "{} - {}",
-                                                          static_cast<uint>(aResponse.statusCode_),
-                                                          Response::StringFromStatusCode(aResponse.statusCode_)
-                                                      );
+    ostk::core::utils::Print::Line(anOutputStream
+    ) << "Status code:"
+      << String::Format(
+             "{} - {}", static_cast<uint>(aResponse.statusCode_), Response::StringFromStatusCode(aResponse.statusCode_)
+         );
     ostk::core::utils::Print::Line(anOutputStream) << "Body:" << aResponse.body_;
 
     ostk::core::utils::Print::Footer(anOutputStream);


### PR DESCRIPTION
[This PR](https://github.com/open-space-collective/open-space-toolkit/pull/169) freezes the `clang` version to 18, which is the latest stable version. This repo had been previously formatted with v20, so I'm re-running `ostk-format-cpp` with v18. 

Contains no changes to business logic. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal code structure to enhance clarity and maintainability.
- **Style**
  - Streamlined formatting across core components for consistent internal operations.

These backend refinements ensure robust performance and pave the way for easier future enhancements, while the end-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->