### PR TITLE
build: fix packaging

### DIFF
--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -43,7 +43,7 @@ ext-modules = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["ostk.io"]
+include = ["ostk.io", "ostk.io.*"]
 
 [tool.setuptools.package-data]
 "ostk.io" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so"]


### PR DESCRIPTION
"submodules" weren't packaged. In this case, it was only stubs that were missing.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Python package distribution so `ostk.io` subpackages are included when installing the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->